### PR TITLE
Change Request ID to UUID

### DIFF
--- a/backend/dal/requestDAL.go
+++ b/backend/dal/requestDAL.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/mbotarro/unijobs/backend/models"
+	"github.com/google/uuid"
 )
 
 // RequestDAL interacts with the DB to perform User related queries
@@ -36,11 +37,15 @@ func (dal *RequestDAL) GetLastRequests(before time.Time, size int) ([]models.Req
 
 // InsertRequest Receives a request as a parameter and inserts into the database
 func (dal *RequestDAL) InsertRequest(request models.Request) error {
-	insertQuery := `INSERT INTO request (name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
-						VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	// Generate an uuid for the request
+	request.ID = uuid.New().String()
+
+	insertQuery := `INSERT INTO request (id, name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
+						VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 
 	// Gets the controller of the database and executes the query
-	_, err := dal.db.Exec(insertQuery, request.Name, request.Description, request.ExtraInfo, request.MinPrice, request.MaxPrice, request.Userid, request.Categoryid, request.Timestamp)
+	_, err := dal.db.Exec(insertQuery, request.ID, request.Name, request.Description, request.ExtraInfo, 
+		request.MinPrice, request.MaxPrice, request.Userid, request.Categoryid, request.Timestamp)
 
 	// Checks if any error happened during the query execution
 	if err != nil {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-pg/migrations v6.7.3+incompatible
 	github.com/go-pg/pg v8.0.4+incompatible
 	github.com/google/go-cmp v0.2.0
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.2
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a
 	github.com/jmoiron/sqlx v1.2.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -36,6 +36,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=

--- a/backend/migrations/4_request_table.up.sql
+++ b/backend/migrations/4_request_table.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS request (
-	id          serial,
+	id          text NOT NULL,
 	name        text NOT NULL,
 	description text, 
 	extrainfo	text NOT NULL,

--- a/backend/migrations/6_test_queries.up.sql
+++ b/backend/migrations/6_test_queries.up.sql
@@ -1,11 +1,11 @@
 insert into userdata(username, password, email, address, telephone, student) values ('Estevam', 'senhateste','estevam@estevam', '', '3258', TRUE);
 insert into userdata(username, password, email, address, telephone, student) values ('user', '1234','user@gmail.com', '', '1234-1234', TRUE);
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Calculo I', '', 20, 40, 2, 1, NOW() - INTERVAL '10 HOUR');
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Calculo II', '', 20, 40, 2, 1, NOW() - INTERVAL '9 HOUR');
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Calculo III', '', 20, 40, 2, 1, NOW() - INTERVAL '8 HOUR');
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Calculo IV', '', 20, 40, 2, 1, NOW() - INTERVAL '7 HOUR');
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Phrasal Verbs', '', 20, 40, 2, 2, NOW() - INTERVAL '6 HOUR');
-insert into request (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('Aula', 'Present Perfect', '', 20, 40, 2, 2, NOW() - INTERVAL '5 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c4694-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Calculo I', '', 20, 40, 2, 1, NOW() - INTERVAL '10 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c4900-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Calculo II', '', 20, 40, 2, 1, NOW() - INTERVAL '9 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c4a40-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Calculo III', '', 20, 40, 2, 1, NOW() - INTERVAL '8 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c4b6c-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Calculo IV', '', 20, 40, 2, 1, NOW() - INTERVAL '7 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c4c98-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Phrasal Verbs', '', 20, 40, 2, 2, NOW() - INTERVAL '6 HOUR');
+insert into request (id, name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp ) values ('a74c506c-8eb2-11e9-bc42-526af7764f64', 'Aula', 'Present Perfect', '', 20, 40, 2, 2, NOW() - INTERVAL '5 HOUR');
 insert into offer (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp) values ('Aula', 'Fisica I', '', 30, 40, 1, 1, NOW() - INTERVAL '10 HOUR');
 insert into offer (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp) values ('Aula', 'Fisica II', '', 30, 40, 1, 1, NOW() - INTERVAL '9 HOUR');
 insert into offer (name, description, extrainfo, minprice, maxprice,  userid, categoryid, timestamp) values ('Aula', 'Fisica III', '', 30, 40, 1, 1, NOW() - INTERVAL '8 HOUR');

--- a/backend/models/request.go
+++ b/backend/models/request.go
@@ -4,7 +4,7 @@ import "time"
 
 // Request represents a user request
 type Request struct {
-	ID          int       `db:"id" json:"id"`
+	ID          string    `db:"id" json:"id"`
 	Name        string    `db:"name" json:"name"`
 	Description string    `db:"description" json:"description"`
 	ExtraInfo   string    `db:"extrainfo" json:"extrainfo"`

--- a/backend/tools/test.go
+++ b/backend/tools/test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/mbotarro/unijobs/backend/models"
 	"gotest.tools/assert"
+	"github.com/google/uuid"
 )
 
 // GetTestDB returns a connection to a DB used for test
@@ -39,10 +40,10 @@ const (
 	getUser        = `SELECT * FROM userdata WHERE email = $1`
 	insertCategory = `INSERT INTO category (name, description) VALUES ($1, $2)`
 	getCategory    = `SELECT * FROM category WHERE name = $1`
-	insertRequest  = `INSERT INTO request (name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
-						VALUES ($1, $2, '', $3, $4, $5, $6, $7)`
+	insertRequest  = `INSERT INTO request (id, name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
+						VALUES ($1, $2, '', $3, $4, $5, $6, $7, $8)`
 
-	getRequest = `SELECT * FROM request WHERE (name, description, userid, categoryid) = ($1, $2, $3, $4)`
+	getRequest = `SELECT * FROM request WHERE id = $1`
   
 	insertOffer = `INSERT INTO offer (name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
 						VALUES ($1, $2, '', $3, $4, $5, $6, $7)`
@@ -82,14 +83,14 @@ func CreateFakeCategory(t *testing.T, db *sqlx.DB, name, description string) mod
 
 // CreateFakeRequest creates a fake request in the db
 func CreateFakeRequest(t *testing.T, db *sqlx.DB, name, description string, user, category int, timestamp time.Time) models.Request {
-	db.MustExec(insertRequest, name, description, 20, 30, user, category, timestamp.UTC())
+	id := uuid.New().String()
+	db.MustExec(insertRequest, id, name, description, 20, 30, user, category, timestamp.UTC())
 
 	r := models.Request{}
-	err := db.Get(&r, getRequest, name, description, user, category)
+	err := db.Get(&r, getRequest, id)
 	assert.Equal(t, nil, err)
 
 	return r
-
 }
 
 // CreateFakeOffer creates a fake request in the db

--- a/docs/testes/relatorio_testes_back.txt
+++ b/docs/testes/relatorio_testes_back.txt
@@ -1,7 +1,7 @@
 ?   	github.com/mbotarro/unijobs/backend	[no test files]
-ok  	github.com/mbotarro/unijobs/backend/dal	(cached)	coverage: 81.8% of statements
+ok  	github.com/mbotarro/unijobs/backend/dal	0.397s	coverage: 75.0% of statements
 ?   	github.com/mbotarro/unijobs/backend/errors	[no test files]
-ok  	github.com/mbotarro/unijobs/backend/handlers	(cached)	coverage: 53.9% of statements
+ok  	github.com/mbotarro/unijobs/backend/handlers	0.233s	coverage: 59.3% of statements
 ?   	github.com/mbotarro/unijobs/backend/migrations	[no test files]
 ?   	github.com/mbotarro/unijobs/backend/models	[no test files]
 ?   	github.com/mbotarro/unijobs/backend/tools	[no test files]

--- a/docs/testes/relatorio_testes_back_completo.html
+++ b/docs/testes/relatorio_testes_back_completo.html
@@ -56,19 +56,21 @@
 				
 				<option value="file0">github.com/mbotarro/unijobs/backend/dal/categoryDAL.go (83.3%)</option>
 				
-				<option value="file1">github.com/mbotarro/unijobs/backend/dal/requestDAL.go (81.8%)</option>
+				<option value="file1">github.com/mbotarro/unijobs/backend/dal/offerDAL.go (45.5%)</option>
 				
-				<option value="file2">github.com/mbotarro/unijobs/backend/dal/userDAL.go (81.8%)</option>
+				<option value="file2">github.com/mbotarro/unijobs/backend/dal/requestDAL.go (81.8%)</option>
 				
-				<option value="file3">github.com/mbotarro/unijobs/backend/handlers/categoryHandler.go (16.7%)</option>
+				<option value="file3">github.com/mbotarro/unijobs/backend/dal/userDAL.go (81.5%)</option>
 				
-				<option value="file4">github.com/mbotarro/unijobs/backend/handlers/offerHandler.go (0.0%)</option>
+				<option value="file4">github.com/mbotarro/unijobs/backend/handlers/categoryHandler.go (16.7%)</option>
 				
-				<option value="file5">github.com/mbotarro/unijobs/backend/handlers/requestHandler.go (73.3%)</option>
+				<option value="file5">github.com/mbotarro/unijobs/backend/handlers/offerHandler.go (72.7%)</option>
 				
-				<option value="file6">github.com/mbotarro/unijobs/backend/handlers/router.go (100.0%)</option>
+				<option value="file6">github.com/mbotarro/unijobs/backend/handlers/requestHandler.go (73.3%)</option>
 				
-				<option value="file7">github.com/mbotarro/unijobs/backend/handlers/userHandler.go (31.7%)</option>
+				<option value="file7">github.com/mbotarro/unijobs/backend/handlers/router.go (100.0%)</option>
+				
+				<option value="file8">github.com/mbotarro/unijobs/backend/handlers/userHandler.go (43.3%)</option>
 				
 				</select>
 			</div>
@@ -122,6 +124,59 @@ import (
         "github.com/mbotarro/unijobs/backend/models"
 )
 
+// OfferDAL interacts with the DB to perform Offer related queries
+type OfferDAL struct {
+        db *sqlx.DB
+}
+
+// NewOfferDAL returns a new OfferDAL
+func NewOfferDAL(db *sqlx.DB) *OfferDAL <span class="cov8" title="1">{
+        return &amp;OfferDAL{
+                db: db,
+        }
+}</span>
+
+// GetLastOffers returns the offers inserted in the dabase before the time specified by timestamp
+// The parameter size limits the number of returned offers
+func (dal *OfferDAL) GetLastOffers(before time.Time, size int) ([]models.Offer, error) <span class="cov8" title="1">{
+        offs := []models.Offer{}
+        err := dal.db.Select(&amp;offs,
+                `SELECT * FROM offer WHERE timestamp &lt; $1
+                        ORDER BY timestamp DESC
+                        LIMIT $2`, before.UTC(), size)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        <span class="cov8" title="1">return offs, nil</span>
+}
+
+// InsertOffer Receives an offer as a parameter and inserts into the database
+func (dal *OfferDAL) InsertOffer(offer models.Offer) error <span class="cov0" title="0">{
+        insertQuery := `INSERT INTO offer (name, description, extrainfo, minprice, maxprice, userid, categoryid, timestamp) 
+                                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+        // Gets the controller of the database and executes the query
+        _, err := dal.db.Exec(insertQuery, offer.Name, offer.Description, offer.ExtraInfo, offer.MinPrice, offer.MaxPrice, offer.Userid, offer.Categoryid, offer.Timestamp)
+
+        // Checks if any error happened during the query execution
+        if err != nil </span><span class="cov0" title="0">{
+                return err
+        }</span>
+
+        <span class="cov0" title="0">return nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file2" style="display: none">package dal
+
+import (
+        "time"
+
+        "github.com/jmoiron/sqlx"
+        "github.com/mbotarro/unijobs/backend/models"
+)
+
 // RequestDAL interacts with the DB to perform User related queries
 type RequestDAL struct {
         db *sqlx.DB
@@ -166,7 +221,7 @@ func (dal *RequestDAL) InsertRequest(request models.Request) error <span class="
 }
 </pre>
 		
-		<pre class="file" id="file2" style="display: none">package dal
+		<pre class="file" id="file3" style="display: none">package dal
 
 import (
         "time"
@@ -236,9 +291,25 @@ func (dal *UserDAL) GetUserRequests(id int, before time.Time, size int) ([]model
 
         <span class="cov8" title="1">return reqs, nil</span>
 }
+
+// GetUserOffers get all offers created by a `user`
+// The `before` parameter is used for pagination. Only the offers created before the time passed by before are returned.
+// `size` limits the number of fetched offers
+func (dal *UserDAL) GetUserOffers(id int, before time.Time, size int) ([]models.Offer, error) <span class="cov8" title="1">{
+        offers := []models.Offer{}
+        err := dal.db.Select(&amp;offers,
+                `SELECT * FROM offer WHERE userid = $1 AND timestamp &lt; $2
+                        ORDER BY timestamp DESC
+                        LIMIT $3`, id, before.UTC(), size)
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, err
+        }</span>
+
+        <span class="cov8" title="1">return offers, nil</span>
+}
 </pre>
 		
-		<pre class="file" id="file3" style="display: none">package handlers
+		<pre class="file" id="file4" style="display: none">package handlers
 
 import (
         "fmt"
@@ -272,35 +343,92 @@ func (handler *CategoryHandler) getAllCategories(w http.ResponseWriter, r *http.
 }
 </pre>
 		
-		<pre class="file" id="file4" style="display: none">package handlers
+		<pre class="file" id="file5" style="display: none">package handlers
 
 import (
-        "encoding/json"
         "fmt"
-        "io/ioutil"
-        "log"
         "net/http"
+        "strconv"
+        "time"
 
+        "github.com/mbotarro/unijobs/backend/errors"
         "github.com/mbotarro/unijobs/backend/models"
+        "github.com/mbotarro/unijobs/backend/tools"
+
+        "github.com/mbotarro/unijobs/backend/usecases"
 )
 
-func createOfferHandler(w http.ResponseWriter, r *http.Request) <span class="cov0" title="0">{
-        body, err := ioutil.ReadAll(r.Body)
+// OfferHandler handle all Offers' API
+type OfferHandler struct {
+        offerController *usecases.OfferController
+}
+
+// NewOfferHandler returns a new OfferHandler
+func NewOfferHandler(offerCtrl *usecases.OfferController) *OfferHandler <span class="cov8" title="1">{
+        return &amp;OfferHandler{
+                offerController: offerCtrl,
+        }
+}</span>
+
+// OfferResponse contains the response sent to the frontend
+type OfferResponse struct {
+        Offers []models.Offer `json:"offers"`
+
+        // Last is the timestamp of the last offer sent to the front. It can be used to get the offers created before it
+        Last int64 `json:"last"`
+}
+
+// OfferInsertion contains the expected input from the frontend
+type OfferInsertion struct {
+        Name        string `json:"name"`
+        Description string `json:"description"`
+        ExtraInfo   string `json:"extrainfo"`
+        MaxPrice    int    `json:"maxprice"`
+        MinPrice    int    `json:"minprice"`
+        Userid      int    `json:"userid"`
+        Categoryid  int    `json:"categoryid"`
+}
+
+// GetLastOffers sends the last offers created in the unijobs service
+func (handler *OfferHandler) GetLastOffers(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
+        sizeStr := r.FormValue("size")
+        size, err := strconv.ParseInt(sizeStr, 10, 32)
         if err != nil </span><span class="cov0" title="0">{
-                panic(err)</span>
+                http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">before := time.Now()
+        beforeStr := r.FormValue("before")
+        if beforeStr != "" </span><span class="cov8" title="1">{
+                beforeInt, err := strconv.ParseInt(beforeStr, 10, 64)
+                if err != nil </span><span class="cov0" title="0">{
+                        http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+                        return
+                }</span>
+
+                <span class="cov8" title="1">before = time.Unix(beforeInt, 0)</span>
         }
 
-        <span class="cov0" title="0">log.Println(string(body))
-        var offerdata models.Offer
-        err = json.Unmarshal(body, &amp;offerdata)
+        <span class="cov8" title="1">offers, err := handler.offerController.GetLastOffers(before, int(size))
         if err != nil </span><span class="cov0" title="0">{
-                panic(err)</span>
+                http.Error(w, fmt.Errorf("%s:%s", errors.DBQueryError, err.Error()).Error(), http.StatusInternalServerError)
+                return
+        }</span>
+
+        <span class="cov8" title="1">reqRes := OfferResponse{
+                Offers: offers,
         }
-        <span class="cov0" title="0">fmt.Fprintf(w, "You've requested the offer: %s\n", offerdata.Name)</span>
+
+        if l := len(offers); l &gt; 0 </span><span class="cov8" title="1">{
+                reqRes.Last = offers[l-1].Timestamp.Unix()
+        }</span>
+
+        <span class="cov8" title="1">tools.WriteStructOnHTTPResponse(reqRes, w)</span>
 }
 </pre>
 		
-		<pre class="file" id="file5" style="display: none">package handlers
+		<pre class="file" id="file6" style="display: none">package handlers
 
 import (
         "encoding/json"
@@ -341,9 +469,9 @@ type RequestResponse struct {
 type RequestInsertion struct {
         Name        string `json:"name"`
         Description string `json:"description"`
-        ExtraInfo   string `json:"extraInfo"`
-        MaxPrice    int    `json:"maxPrice"`
-        MinPrice    int    `json:"minPrice"`
+        ExtraInfo   string `json:"extrainfo"`
+        MaxPrice    int    `json:"maxprice"`
+        MinPrice    int    `json:"minprice"`
         Userid      int    `json:"userid"`
         Categoryid  int    `json:"categoryid"`
 }
@@ -423,7 +551,7 @@ func (handler *RequestHandler) InsertRequest(w http.ResponseWriter, r *http.Requ
 }
 </pre>
 		
-		<pre class="file" id="file6" style="display: none">package handlers
+		<pre class="file" id="file7" style="display: none">package handlers
 
 import (
         "github.com/gorilla/mux"
@@ -444,9 +572,10 @@ func NewRouter(ctrl *usecases.Controller) *mux.Router <span class="cov8" title="
         userHandler := NewUserHandler(ctrl.User)
         categoryHandler := NewCategoryHandler(ctrl.Category)
         requestHandler := NewRequestHandler(ctrl.Request)
+        offerHandler := NewOfferHandler(ctrl.Offer)
 
         route.r.HandleFunc("/createUser", createUserHandler).Methods("POST")
-        route.r.HandleFunc("/createOffer", createOfferHandler).Methods("POST")
+        //route.r.HandleFunc("/createOffer", createOfferHandler).Methods("POST")
 
         // User APIs
         route.r.Path("/users/authenticate").
@@ -462,6 +591,14 @@ func NewRouter(ctrl *usecases.Controller) *mux.Router <span class="cov8" title="
         route.r.Path("/users/{id:[0-9]+}/requests").
                 Queries("size", "{size:[0-9]+}").
                 HandlerFunc(userHandler.GetUserRequests).
+                Methods("GET")
+        route.r.Path("/users/{id:[0-9]+}/offers").
+                Queries("size", "{size:[0-9]+}", "before", "{before:[0-9]+}").
+                HandlerFunc(userHandler.GetUserOffers).
+                Methods("GET")
+        route.r.Path("/users/{id:[0-9]+}/offers").
+                Queries("size", "{size:[0-9]+}").
+                HandlerFunc(userHandler.GetUserOffers).
                 Methods("GET")
 
         // Request APIs
@@ -485,11 +622,24 @@ func NewRouter(ctrl *usecases.Controller) *mux.Router <span class="cov8" title="
         // Categories API
         route.r.HandleFunc("/categories", categoryHandler.getAllCategories).Methods("GET")
 
+        // Offers APIs
+        // Get last offers
+        route.r.Path("/offers").
+                Queries("size", "{size:[0-9]+}").
+                HandlerFunc(offerHandler.GetLastOffers).
+                Methods("GET")
+
+        // Get last offers with paging
+        route.r.Path("/offers").
+                Queries("size", "{size:[0-9]+}", "before", "{before:[0-9]+}").
+                HandlerFunc(offerHandler.GetLastOffers).
+                Methods("GET")
+
         return &amp;route.r
 }</span>
 </pre>
 		
-		<pre class="file" id="file7" style="display: none">package handlers
+		<pre class="file" id="file8" style="display: none">package handlers
 
 import (
         "encoding/json"
@@ -640,6 +790,52 @@ func (handler *UserHandler) GetUserRequests(w http.ResponseWriter, r *http.Reque
         }</span>
 
         <span class="cov8" title="1">tools.WriteStructOnHTTPResponse(reqRes, w)</span>
+}
+
+// GetUserOffers return Offers required by the user
+func (handler *UserHandler) GetUserOffers(w http.ResponseWriter, r *http.Request) <span class="cov8" title="1">{
+        vars := mux.Vars(r)
+        idStr := vars["id"]
+        id, err := strconv.ParseInt(idStr, 10, 32)
+        if err != nil </span><span class="cov0" title="0">{
+                http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">sizeStr := r.FormValue("size")
+        size, err := strconv.ParseInt(sizeStr, 10, 32)
+        if err != nil </span><span class="cov0" title="0">{
+                http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+                return
+        }</span>
+
+        <span class="cov8" title="1">before := time.Now()
+        beforeStr := r.FormValue("before")
+        if beforeStr != "" </span><span class="cov8" title="1">{
+                beforeInt, err := strconv.ParseInt(beforeStr, 10, 64)
+                if err != nil </span><span class="cov0" title="0">{
+                        http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+                        return
+                }</span>
+
+                <span class="cov8" title="1">before = time.Unix(beforeInt, 0)</span>
+        }
+
+        <span class="cov8" title="1">offers, err := handler.userController.GetUserOffers(int(id), before, int(size))
+        if err != nil </span><span class="cov0" title="0">{
+                http.Error(w, fmt.Errorf("%s:%s", errors.DBQueryError, err.Error()).Error(), http.StatusInternalServerError)
+                return
+        }</span>
+
+        <span class="cov8" title="1">offerRes := OfferResponse{
+                Offers: offers,
+        }
+
+        if l := len(offers); l &gt; 0 </span><span class="cov8" title="1">{
+                offerRes.Last = offers[l-1].Timestamp.Unix()
+        }</span>
+
+        <span class="cov8" title="1">tools.WriteStructOnHTTPResponse(offerRes, w)</span>
 }
 </pre>
 		


### PR DESCRIPTION
This PR changes the ID from a Request from int to UUID. A request ID was generated automatically by Postgres during a Request insertion. However, a requestID will be needed to put the request in Elastic Search too. So, we moved the ID generation to the server and changed the Request table to accept the string representation of an UUID. 

The following items have been updated as well:
- Request examples inserted in Postgres during migration to include UUID
- Auxiliar test functions to create fake requests