### PR TITLE
Improve Request Search

### DIFF
--- a/backend/dal/requestDAL_test.go
+++ b/backend/dal/requestDAL_test.go
@@ -391,6 +391,14 @@ func TestSearchRequestInES(t *testing.T){
 			assert.Equal(t, req4.ID, ids[3])
 		})
 	})
+
+	t.Run("No matched requests", func(t *testing.T){
+		ids, err := requestDAL.SearchInES("eps")
+
+			// We expect to get just Pet Care: it's the only one with passear in either name or description
+			assert.Equal(t, nil, err)
+			assert.Equal(t, 0, len(ids))
+	})
 }
 
 func TestSearchRequestWithCategoryInES(t *testing.T){

--- a/backend/handlers/requestHandler_test.go
+++ b/backend/handlers/requestHandler_test.go
@@ -252,7 +252,7 @@ func TestSearchRequest(t *testing.T) {
 	req6 := tools.CreateFakeRequest(t, db, "Aula de ICC II", "Ajuda em prova", u.Userid, c2.ID, time.Now().Add(-7*time.Hour))
 
 	// Insert requests in ES
-	for _, req := range []models.Request{req1, req2, req3, req4, req5, req6}{
+	for _, req := range []models.Request{req1, req2, req3, req4, req5, req6} {
 		err := ctrl.Request.InsertRequestInES(req)
 		assert.Equal(t, nil, err)
 	}
@@ -274,7 +274,7 @@ func TestSearchRequest(t *testing.T) {
 
 		expected := handlers.RequestResponse{
 			Requests: []models.Request{req3, req2, req1}, // In creation descending order
-			Last:     0, // Search doesn't have pagination
+			Last:     0,                                  // Search doesn't have pagination
 		}
 		expectedJs, err := json.Marshal(expected)
 		assert.Equal(t, nil, err)
@@ -282,80 +282,106 @@ func TestSearchRequest(t *testing.T) {
 		assert.Equal(t, string(expectedJs), rr.Body.String())
 	})
 
-	t.Run("get request from 2 categories", func(t *testing.T){
-		t.Run("not specifying the categories", func(t *testing.T){
+	t.Run("get request from 2 categories", func(t *testing.T) {
+		t.Run("not specifying the categories", func(t *testing.T) {
 			req, err := http.NewRequest("GET", "/requests?q=prova", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		rr := httptest.NewRecorder()
+			rr := httptest.NewRecorder()
 
-		handler.ServeHTTP(rr, req)
+			handler.ServeHTTP(rr, req)
 
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 
-		}
+			}
 
-		expected := handlers.RequestResponse{
-			Requests: []models.Request{req6, req5, req4, req2}, // In creation descending order
-			Last:     0, // Search doesn't have pagination
-		}
-		expectedJs, err := json.Marshal(expected)
-		assert.Equal(t, nil, err)
+			expected := handlers.RequestResponse{
+				Requests: []models.Request{req6, req5, req4, req2}, // In creation descending order
+				Last:     0,                                        // Search doesn't have pagination
+			}
+			expectedJs, err := json.Marshal(expected)
+			assert.Equal(t, nil, err)
 
-		assert.Equal(t, string(expectedJs), rr.Body.String())
+			assert.Equal(t, string(expectedJs), rr.Body.String())
 		})
 
-		t.Run("specifying both categories", func(t *testing.T){
+		t.Run("specifying both categories", func(t *testing.T) {
 			req, err := http.NewRequest("GET", fmt.Sprintf("/requests?q=prova&cat=%d,%d", c1.ID, c2.ID), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		rr := httptest.NewRecorder()
+			rr := httptest.NewRecorder()
 
-		handler.ServeHTTP(rr, req)
+			handler.ServeHTTP(rr, req)
 
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 
-		}
+			}
 
-		expected := handlers.RequestResponse{
-			Requests: []models.Request{req6, req5, req4, req2}, // In creation descending order
-			Last:     0, // Search doesn't have pagination
-		}
-		expectedJs, err := json.Marshal(expected)
-		assert.Equal(t, nil, err)
+			expected := handlers.RequestResponse{
+				Requests: []models.Request{req6, req5, req4, req2}, // In creation descending order
+				Last:     0,                                        // Search doesn't have pagination
+			}
+			expectedJs, err := json.Marshal(expected)
+			assert.Equal(t, nil, err)
 
-		assert.Equal(t, string(expectedJs), rr.Body.String())
+			assert.Equal(t, string(expectedJs), rr.Body.String())
 		})
 
-		t.Run("just one category", func(t *testing.T){
+		t.Run("just one category", func(t *testing.T) {
 			req, err := http.NewRequest("GET", fmt.Sprintf("/requests?q=prova&cat=%d", c2.ID), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		rr := httptest.NewRecorder()
+			rr := httptest.NewRecorder()
 
-		handler.ServeHTTP(rr, req)
+			handler.ServeHTTP(rr, req)
 
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 
-		}
+			}
 
-		expected := handlers.RequestResponse{
-			Requests: []models.Request{req6, req5}, // In creation descending order
-			Last:     0, // Search doesn't have pagination
-		}
-		expectedJs, err := json.Marshal(expected)
-		assert.Equal(t, nil, err)
+			expected := handlers.RequestResponse{
+				Requests: []models.Request{req6, req5}, // In creation descending order
+				Last:     0,                            // Search doesn't have pagination
+			}
+			expectedJs, err := json.Marshal(expected)
+			assert.Equal(t, nil, err)
 
-		assert.Equal(t, string(expectedJs), rr.Body.String())
+			assert.Equal(t, string(expectedJs), rr.Body.String())
 		})
 	})
+
+	t.Run("No matched request", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/requests?q=eps", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+
+		}
+
+		expected := handlers.RequestResponse{
+			Requests: []models.Request{}, // We expect to get no request
+			Last:     0,                  // Search doesn't have pagination
+		}
+		expectedJs, err := json.Marshal(expected)
+		assert.Equal(t, nil, err)
+
+		assert.Equal(t, string(expectedJs), rr.Body.String())
+	})
+
 }


### PR DESCRIPTION
When a query that doesn't match any request document was passed, the Postgres raised an error because an empty slice of IDs was used to query it. 

This PR:
- Adds a test to assure that an empty vector is sent to the frontend if there's no matched request
- Updates the SearchRequest method to only query Postgres if we get a non-empty slice from ES.