### PR TITLE
Add match tables, insertion, getstatus and API

### DIFF
--- a/backend/dal/offerDAL.go
+++ b/backend/dal/offerDAL.go
@@ -137,10 +137,10 @@ func (dal *OfferDAL) SearchInES(query string, categoryIDs ...int) ([]string, err
 }
 
 // InsertOfferMatch receives the id of the user and the offer and inserts the match into the match table
-func (dal *OfferDAL) InsertOfferMatch(userid, offerid string) error {
+func (dal *OfferDAL) InsertOfferMatch(userid int, offerid string) error {
 	// Checks if the offer is valid
 	off := models.Offer{}
-	err := dal.db.Select(off,
+	err := dal.db.Get(&off,
 		`SELECT * FROM offer WHERE ID = $1
 			LIMIT 1`, offerid)
 	if err != nil {
@@ -152,7 +152,7 @@ func (dal *OfferDAL) InsertOfferMatch(userid, offerid string) error {
 
 	// Checks if the user is valid
 	user := models.User{}
-	err = dal.db.Select(user,
+	err = dal.db.Get(&user,
 		`SELECT * FROM USERDATA WHERE USERID = $1
 			LIMIT 1`, userid)
 	if err != nil {
@@ -162,7 +162,7 @@ func (dal *OfferDAL) InsertOfferMatch(userid, offerid string) error {
 		return fmt.Errorf("%s:%s", errors.UserNotFound, err.Error())
 	}
 
-	insertQuery := `INSERT INTO match (userid, offerid) 
+	insertQuery := `INSERT INTO match(userid, offerid) 
 						VALUES ($1, $2)`
 
 	// Gets the controller of the database and executes the query
@@ -172,4 +172,22 @@ func (dal *OfferDAL) InsertOfferMatch(userid, offerid string) error {
 	}
 
 	return nil
+}
+
+// GetOfferMatchStatus receives the id of the user and the offer and inserts the match into the match table
+func (dal *OfferDAL) GetOfferMatchStatus(userid int, offerid string) (bool, error) {
+	selectQuery := `SELECT count(*) from match
+						WHERE userid = $1 
+						AND offerid = $2`
+
+	var count int
+	err := dal.db.Get(&count, selectQuery, userid, offerid)
+	fmt.Printf("%d\n", count)
+	if err != nil {
+		return false, err
+	}
+	if count == 0 {
+		return false, nil
+	}
+	return true, nil
 }

--- a/backend/dal/offerDAL.go
+++ b/backend/dal/offerDAL.go
@@ -135,3 +135,41 @@ func (dal *OfferDAL) SearchInES(query string, categoryIDs ...int) ([]string, err
 
 	return ids, nil
 }
+
+// InsertOfferMatch receives the id of the user and the offer and inserts the match into the match table
+func (dal *OfferDAL) InsertOfferMatch(userid, offerid string) error {
+	// Checks if the offer is valid
+	off := models.Offer{}
+	err := dal.db.Select(off,
+		`SELECT * FROM offer WHERE ID = $1
+			LIMIT 1`, offerid)
+	if err != nil {
+		return err
+	}
+	if off.ID == "" {
+		return fmt.Errorf("%s:%s", errors.OfferNotFound, err.Error())
+	}
+
+	// Checks if the user is valid
+	user := models.User{}
+	err = dal.db.Select(user,
+		`SELECT * FROM USERDATA WHERE USERID = $1
+			LIMIT 1`, userid)
+	if err != nil {
+		return err
+	}
+	if user.Userid == 0 {
+		return fmt.Errorf("%s:%s", errors.UserNotFound, err.Error())
+	}
+
+	insertQuery := `INSERT INTO match (userid, offerid) 
+						VALUES ($1, $2)`
+
+	// Gets the controller of the database and executes the query
+	_, err = dal.db.Exec(insertQuery, userid, offerid)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -660,3 +660,20 @@ So far, the search endpoint doesn't accept pagination, always returning all matc
   }
 ]
 ```
+
+# Match API
+
+### Insert offer match into database
+
+### POST
+To match the offer with id \<offerid\> with the user <userid>
+```
+/offers/<offerid>/users/<userid>
+```
+#### Expected Response 
+A valid insert returns a 201 HTTP Status Code.
+```
+HTTP/1.1 201 Created
+Date: Wed, 05 Jun 2019 12:00:59 GMT
+Content-Length: 0
+```

--- a/backend/errors/errors.go
+++ b/backend/errors/errors.go
@@ -19,9 +19,15 @@ const (
 )
 
 // Common ES errors
-const(
+const (
 	ESConnectionError = "Can't connect to ES"
 	ESUnmarshallError = "Can't unmarshall ES response"
-	ESInsertError = "Can't insert document in ES"
-	ESSearchError = "Can't search for documento in ES"
+	ESInsertError     = "Can't insert document in ES"
+	ESSearchError     = "Can't search for documento in ES"
+)
+
+// Common match errors
+const (
+	UserNotFound  = "User not found"
+	OfferNotFound = "Offer not found"
 )

--- a/backend/handlers/offerHandler.go
+++ b/backend/handlers/offerHandler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/mbotarro/unijobs/backend/errors"
 	"github.com/mbotarro/unijobs/backend/models"
 	"github.com/mbotarro/unijobs/backend/tools"
@@ -159,4 +160,30 @@ func (handler *OfferHandler) SearchOffers(w http.ResponseWriter, r *http.Request
 	}
 
 	tools.WriteStructOnHTTPResponse(offRes, w)
+}
+
+// InsertOfferMatch inserts the match of a given user with an offer, it receives a json with the offer id
+func (handler *OfferHandler) InsertOfferMatch(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	// Gets offer id
+	offerid := vars["offerid"]
+	// Gets user id
+	idStr := vars["userid"]
+
+	fmt.Print(offerid, "\n")
+
+	uid64, err := strconv.ParseInt(idStr, 10, 32)
+	if err != nil {
+		http.Error(w, fmt.Errorf("%s:%s", errors.QueryParameterError, err.Error()).Error(), http.StatusBadRequest)
+		return
+	}
+	userid := int(uid64)
+
+	err = handler.offerController.InsertOfferMatch(userid, offerid)
+	if err != nil {
+		http.Error(w, fmt.Errorf("%s:%s", errors.DBQueryError, err.Error()).Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }

--- a/backend/handlers/offerHandler_test.go
+++ b/backend/handlers/offerHandler_test.go
@@ -399,14 +399,13 @@ func TestInsertOfferMatch(t *testing.T) {
 	defer tools.CleanES(es)
 
 	ctrl := usecases.NewController(db, es)
-	ch := handlers.NewOfferHandler(ctrl.Offer)
+
+	router := handlers.NewRouter(ctrl)
 
 	// Creates fake user and category to be used at the offer
 	u := tools.CreateFakeUser(t, db, "user", "user@user.com", "1234", "9999-1111")
 	c := tools.CreateFakeCategory(t, db, "Aula Matemática", "Matemática")
 	off := tools.CreateFakeOffer(t, db, "Aula de Cálculo I", "Oferecço aula particular", u.Userid, c.ID, time.Now().Add(-10*time.Hour))
-
-	handler := http.HandlerFunc(ch.InsertOfferMatch)
 
 	///offers/{offer-id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/users/{user-id:[0-9]+}
 
@@ -415,7 +414,7 @@ func TestInsertOfferMatch(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	reqRecord := httptest.NewRecorder()
-	handler.ServeHTTP(reqRecord, req)
+	router.ServeHTTP(reqRecord, req)
 
 	status := reqRecord.Code
 	assert.Equal(t, 201, status)

--- a/backend/handlers/offerHandler_test.go
+++ b/backend/handlers/offerHandler_test.go
@@ -391,3 +391,32 @@ func TestSearchOffer(t *testing.T) {
 	})
 
 }
+
+func TestInsertOfferMatch(t *testing.T) {
+	db := tools.GetTestDB()
+	es := tools.GetTestES()
+	defer tools.CleanDB(db)
+	defer tools.CleanES(es)
+
+	ctrl := usecases.NewController(db, es)
+	ch := handlers.NewOfferHandler(ctrl.Offer)
+
+	// Creates fake user and category to be used at the offer
+	u := tools.CreateFakeUser(t, db, "user", "user@user.com", "1234", "9999-1111")
+	c := tools.CreateFakeCategory(t, db, "Aula Matemática", "Matemática")
+	off := tools.CreateFakeOffer(t, db, "Aula de Cálculo I", "Oferecço aula particular", u.Userid, c.ID, time.Now().Add(-10*time.Hour))
+
+	handler := http.HandlerFunc(ch.InsertOfferMatch)
+
+	///offers/{offer-id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/users/{user-id:[0-9]+}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("/offers/%s/users/%d", off.ID, u.Userid), nil)
+
+	assert.Equal(t, nil, err)
+
+	reqRecord := httptest.NewRecorder()
+	handler.ServeHTTP(reqRecord, req)
+
+	status := reqRecord.Code
+	assert.Equal(t, 201, status)
+}

--- a/backend/handlers/router.go
+++ b/backend/handlers/router.go
@@ -111,5 +111,10 @@ func NewRouter(ctrl *usecases.Controller) *mux.Router {
 		HandlerFunc(offerHandler.InsertOffer).
 		Methods("POST")
 
+	// Inserts a new match of the offer-id and user-id given
+	route.r.Path("/offers/{offerid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/users/{userid:[0-9]+}").
+		HandlerFunc(offerHandler.InsertOfferMatch).
+		Methods("POST")
+
 	return &route.r
 }

--- a/backend/migrations/7_match_table.up.sql
+++ b/backend/migrations/7_match_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS match (
+	userid      serial,
+	offerid     serial,  
+	CONSTRAINT pk_category PRIMARY KEY (userid, offerid),
+    FOREIGN KEY (userid) REFERENCES userdata(userid),
+    FOREIGN KEY (offerid) REFERENCES offer(id)
+);

--- a/backend/migrations/7_match_table.up.sql
+++ b/backend/migrations/7_match_table.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS match (
 	userid      serial,
-	offerid     serial,  
-	CONSTRAINT pk_category PRIMARY KEY (userid, offerid),
+	offerid     text,  
+	CONSTRAINT pk_match PRIMARY KEY (userid, offerid),
     FOREIGN KEY (userid) REFERENCES userdata(userid),
     FOREIGN KEY (offerid) REFERENCES offer(id)
 );

--- a/backend/models/match.go
+++ b/backend/models/match.go
@@ -2,6 +2,6 @@ package models
 
 // Match represents an interest between a user and an offer.
 type Match struct {
-	Userid  string `db:"userid" json:"userid"`
+	Userid  int    `db:"userid" json:"userid"`
 	Offerid string `db:"offerid" json:"offerid"`
 }

--- a/backend/models/match.go
+++ b/backend/models/match.go
@@ -1,0 +1,7 @@
+package models
+
+// Match represents an interest between a user and an offer.
+type Match struct {
+	Userid  string `db:"userid" json:"userid"`
+	Offerid string `db:"offerid" json:"offerid"`
+}

--- a/backend/tools/test.go
+++ b/backend/tools/test.go
@@ -54,6 +54,7 @@ func CleanES(es *elastic.Client) {
 
 // CleanDB delete all rows from all DB tables
 func CleanDB(db *sqlx.DB) {
+	db.MustExec("DELETE FROM match")
 	db.MustExec("DELETE FROM request")
 	db.MustExec("DELETE FROM offer")
 	db.MustExec("DELETE FROM category")

--- a/backend/usecases/offerCases.go
+++ b/backend/usecases/offerCases.go
@@ -81,3 +81,12 @@ func (oc *OfferController) SearchOffers(query string, categoryIDs ...int) ([]mod
 
 	return reqs, nil
 }
+
+// InsertOfferMatch receives the id of the user and the offer and inserts the match into the match table
+func (oc *OfferController) InsertOfferMatch(userid int, offerid string) error {
+	err := oc.offerDAL.InsertOfferMatch(userid, offerid)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/docs/testes/relatorio_testes_back.txt
+++ b/docs/testes/relatorio_testes_back.txt
@@ -1,7 +1,7 @@
 ?   	github.com/mbotarro/unijobs/backend	[no test files]
-ok  	github.com/mbotarro/unijobs/backend/dal	(cached)	coverage: 83.2% of statements
+ok  	github.com/mbotarro/unijobs/backend/dal	1.629s	coverage: 83.4% of statements
 ?   	github.com/mbotarro/unijobs/backend/errors	[no test files]
-ok  	github.com/mbotarro/unijobs/backend/handlers	(cached)	coverage: 63.6% of statements
+ok  	github.com/mbotarro/unijobs/backend/handlers	0.608s	coverage: 64.2% of statements
 ?   	github.com/mbotarro/unijobs/backend/migrations	[no test files]
 ?   	github.com/mbotarro/unijobs/backend/models	[no test files]
 ?   	github.com/mbotarro/unijobs/backend/tools	[no test files]


### PR DESCRIPTION
Add match tables
    models/match.go     | Add match at models, containing userid and offerid
    migrations/7_match_table.go.sql | Add match at postgres database

API p/ Match
    Insert Match (Offer) 
        dal/offerDAL.go     | Add InsertOfferMatch function 
        errors/errors.go    | Add UserNotFound and OfferNotFound errors
        usecases/offerCases.go  | Add InsertOfferMatch function
    Create Handlers
        handlers/router.go               | POST  /offers/<offer-id>/users/<user-id>
        handlers/offerHandler.go         | Add InsertOfferMatch function (calls controller)
    DOCS
        docs/API.models         | Add docs of the handlers added. 
                                    POST /offers/<offer-id>/users/<user-id>
    Testing
        handlers
            handlers/offerHandler_test.go         | Add InsertOfferMatch function (calls controller)
        dal              
            dal/offerDAL_test.go | Add InsertOfferMatch test